### PR TITLE
商品購入確認ページのフロント実装

### DIFF
--- a/app/assets/stylesheets/_purchase.scss
+++ b/app/assets/stylesheets/_purchase.scss
@@ -1,0 +1,115 @@
+* {
+  box-sizing: border-box;
+}
+
+.link-to-register {
+  text-decoration: none;
+  color: rgb(66, 162, 201);
+}
+
+.link-to-purchase {
+  padding: 20px 40%;
+  background-color: slategray;
+  color: white;
+  font-size: 14px;
+  font-weight: bold;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.purchase-main {
+  margin: 5% 25%;
+  &__container {
+    width: 100%;
+    margin: 0 auto;
+    &__title {
+      font-size: 32px;
+      font-weight: bold;
+      padding: 24px;
+      text-align: center;
+    }
+    &__buy-item {
+      padding: 24px;
+      &__inner {
+        max-width: 343px;
+        margin: 0 auto;
+        &__box {
+          display: flex;
+          &__image {
+            height:  160px;
+            width: 160px;
+            min-width: 160px;
+            img {
+              width: 160px;
+            }
+          }
+          &__detail {
+            padding-top: 64px;
+            margin-left: 32px;
+            height: 160px;
+            width: 160px;
+            &__name {
+              font-size: 24px;
+              font-weight: bold;
+              margin: 0;
+              padding-bottom: 8px;
+            }
+            &__price {
+              font-size:20px;
+              font-weight: bold;
+            }
+          }
+        }
+      }
+    }
+    &__bottom {
+      padding: 16px 40px;
+      &__inner {
+        max-width: 343px;
+        margin: 0 auto;
+        &__pay {
+          display: flex;
+          justify-content: space-between;
+          line-height: 1.5;
+          border-bottom: 1px solid #f5f5f5;
+          &__amount {
+            padding-top: 16px;
+            font-size: 20px;
+            font-weight: bold;
+          }
+          &__price {
+            font-size: 36px;
+            font-weight: bold;
+          }
+        }
+        &__select {
+          padding: 32px 0;
+          &__method {
+            margin-bottom: 32px;
+            &__box {
+              padding-bottom: 8px;
+              border-bottom: 1px solid #f5f5f5;
+              &__top {
+                font-size: 14px;
+              }
+            }
+          }
+          &__delivery {
+            padding: 24px 0;
+            &__address {
+              padding-bottom: 8px;
+              border-bottom: 1px solid #f5f5f5;
+              &__top {
+                font-size: 14px;
+              }
+            }
+          }
+          &__btn {
+            text-align: center;
+            margin-top: 32px;
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,3 +5,4 @@
 @import "footer_view";
 @import "new-reg";
 @import "item_new";
+@import "purchase";

--- a/app/views/purchase/index.html.haml
+++ b/app/views/purchase/index.html.haml
@@ -1,31 +1,42 @@
+= render "devise/header_view"
+
 .purchase-main
   .purchase-main__container
     %h2.purchase-main__container__title
+      購入内容の確認
     .purchase-main__container__buy-item
       .purchase-main__container__buy-item__inner
         .purchase-main__container__buy-item__inner__box
-          %h3.purchase-main__container__buy-item__inner__box__image
-        .purchase-main__container__buy-item__inner__box__detail
-          %p.purchase-main__container__buy-item__inner__box__detail__name
-          %p.purchase-main__container__buy-item__inner__box__detail__price
-            %span 333円
-            %span.tax-included (税込)
+          .purchase-main__container__buy-item__inner__box__image
+            = image_tag("/assets/item/item02.png")
+          .purchase-main__container__buy-item__inner__box__detail
+            %p.purchase-main__container__buy-item__inner__box__detail__name
+              テスト商品
+            %p.purchase-main__container__buy-item__inner__box__detail__price
+              %span 333円
+              %span.tax-included (税込)
 
-    .purchase-main__select__inner
-      .purchase-main__select__inner__pay
-        .purchase-main__select__inner__pay__amount
-        .purchase-main__select__inner__pay__price
-  
-        .purchase-main__select__inner__pay__method
-          .purchase-main__select__inner__pay__method__box
-            %h3.purchase-main__select__inner__pay__method__box__top
-              支払い方法
-            = link_to "登録してください", root_path
+    .purchase-main__container__bottom
+      .purchase-main__container__bottom__inner
 
-        .purchase-main__select__inner__pay__adress
-          .purchase-main__select__inner__pay__adress__box
-            %h3.purchase-main__select__inner__pay__adress__box__top
-              配送先
-            = link_to "登録してください", root_path
+        .purchase-main__container__bottom__inner__pay
+          .purchase-main__container__bottom__inner__pay__amount
+            支払い金額
+          .purchase-main__container__bottom__inner__pay__price
+            333円
+        .purchase-main__container__bottom__inner__select
+          .purchase-main__container__bottom__inner__select__method
+            .purchase-main__container__bottom__inner__select__method__box
+              %h3.purchase-main__container__bottom__inner__select__method__box__top
+                支払い方法
+              = link_to "登録してください", root_path, class:"link-to-register"
 
-        .purchase-main__select__inner__pay__btn
+          .purchase-main__container__bottom__inner__select__delivery
+            .purchase-main__container__bottom__inner__select__delivery__address
+              %h3.purchase-main__container__bottom__inner__select__delivery__address__top
+                配送先
+              = link_to "登録してください", root_path, class:"link-to-register"
+          .purchase-main__container__bottom__inner__select__btn
+            = link_to "購入する", root_path, class: "btn link-to-purchase"
+
+= render "devise/footer_view"


### PR DESCRIPTION
# What
商品詳細ページから遷移する購入確認ページの実装
purchaseコントローラーを作成し、indexアクションに仮設定
localhost:3000/purchaseで確認できます
# Why
サーバーサイド作業に入る前の準備として作成
